### PR TITLE
[Feat] 새로운 과목 추가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }
 
 dependencyManagement {

--- a/src/main/java/Codify/submit/config/SwaggerConfig.java
+++ b/src/main/java/Codify/submit/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package Codify.submit.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI CodifySubmitAPI() {
+        Info info = new Info()
+                .title("Codify Submit API")
+                .description("Codify Submit API 명세서")
+                .version("1.0.0");
+
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info);
+    }
+}

--- a/src/main/java/Codify/submit/domain/Subjects.java
+++ b/src/main/java/Codify/submit/domain/Subjects.java
@@ -1,0 +1,37 @@
+package Codify.submit.domain;
+
+import jakarta.persistence.*;
+
+import java.util.UUID;
+
+@Entity
+public class Subjects {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long subjectId;
+
+    @Column(name = "userUuid", nullable = false, columnDefinition = "BINARY(16)")
+    private UUID userUuid;
+
+    @Column(name = "subjectName", nullable = false, length = 255)
+    private String subjectName;
+
+    protected Subjects() { }
+
+    public Subjects(UUID userUuid, String subjectName) {
+        this.userUuid = userUuid;
+        this.subjectName = subjectName;
+    }
+
+    public Long getSubjectId() {
+        return subjectId;
+    }
+
+    public UUID getUserUuid() {
+        return userUuid;
+    }
+    public String getSubjectName() {
+        return subjectName;
+    }
+}

--- a/src/main/java/Codify/submit/exception/ErrorCode.java
+++ b/src/main/java/Codify/submit/exception/ErrorCode.java
@@ -10,6 +10,11 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E3", "서버 에러가 발생했습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "E4", "존재하지 않는 엔티티입니다."),
 
+    SUBJECT_ALREADY_EXISTS(HttpStatus.CONFLICT, "S1", "이미 존재하는 과목입니다"),
+    EMPTY_SUBJECT_NAME(HttpStatus.BAD_REQUEST, "S2", "과목명이 비어있습니다."),
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U1", "존재하지 않는 사용자입니다."),
+
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "A1", "존재하지 않는 아티클입니다.");
 
     private final HttpStatus status; //http 상태 코드

--- a/src/main/java/Codify/submit/exception/InvalidSubjectNameException.java
+++ b/src/main/java/Codify/submit/exception/InvalidSubjectNameException.java
@@ -1,0 +1,9 @@
+package Codify.submit.exception;
+
+import Codify.submit.exception.baseException.BaseException;
+
+public class InvalidSubjectNameException extends BaseException {
+    public InvalidSubjectNameException() {
+        super(ErrorCode.EMPTY_SUBJECT_NAME);
+    }
+}

--- a/src/main/java/Codify/submit/exception/SubjectAlreadyExistsException.java
+++ b/src/main/java/Codify/submit/exception/SubjectAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package Codify.submit.exception;
+
+import Codify.submit.exception.baseException.BaseException;
+
+public class SubjectAlreadyExistsException extends BaseException {
+    public SubjectAlreadyExistsException() {
+        super(ErrorCode.SUBJECT_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/Codify/submit/exception/UserNotFoundException.java
+++ b/src/main/java/Codify/submit/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package Codify.submit.exception;
+
+import Codify.submit.exception.baseException.BaseException;
+
+public class UserNotFoundException extends BaseException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/Codify/submit/repository/SubjectRepository.java
+++ b/src/main/java/Codify/submit/repository/SubjectRepository.java
@@ -1,0 +1,8 @@
+package Codify.submit.repository;
+
+import Codify.submit.domain.Subjects;
+import org.springframework.data.jpa.repository.*;
+
+public interface SubjectRepository extends JpaRepository<Subjects, Long> {
+
+}

--- a/src/main/java/Codify/submit/service/SubjectService.java
+++ b/src/main/java/Codify/submit/service/SubjectService.java
@@ -1,0 +1,48 @@
+package Codify.submit.service;
+
+import Codify.submit.domain.Subjects;
+import Codify.submit.exception.InvalidSubjectNameException;
+import Codify.submit.exception.SubjectAlreadyExistsException;
+import Codify.submit.exception.UserNotFoundException;
+import Codify.submit.repository.SubjectRepository;
+import Codify.submit.web.dto.SubjectRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SubjectService {
+    private final SubjectRepository subjectRepository;
+
+    @Transactional
+    public Long create(UUID userUuid, SubjectRequestDto subjectRequestDto) {
+        String raw = subjectRequestDto.getSubjectName();
+        if (raw == null || raw.trim().isEmpty()) {
+            throw new InvalidSubjectNameException();
+        }
+        String name = raw.trim();
+
+        try {
+            Subjects saved = subjectRepository.save(new Subjects(userUuid, name));
+            return saved.getSubjectId();
+        } catch (DataIntegrityViolationException e) {
+            // custom exception
+            // 제약이름으로만 잡히지 않는 에러가 있어서 MySQL 에러코드로도 처리 (1062=중복, 1452=FK 위반)
+            Throwable root = NestedExceptionUtils.getMostSpecificCause(e);
+            if (root instanceof java.sql.SQLIntegrityConstraintViolationException sqlx) {
+                int code = sqlx.getErrorCode();
+                // 중복된 과목은 스프링 시큐리티 구현 후 추가 예정
+                // if (code == 1062) throw new SubjectAlreadyExistsException();
+                if (code == 1452) throw new UserNotFoundException();
+            }
+            // 그 외: 전역 핸들러
+            throw e;
+        }
+    }
+}

--- a/src/main/java/Codify/submit/web/controller/SubjectController.java
+++ b/src/main/java/Codify/submit/web/controller/SubjectController.java
@@ -1,0 +1,28 @@
+package Codify.submit.web.controller;
+
+
+import Codify.submit.service.SubjectService;
+import Codify.submit.web.dto.SubjectRequestDto;
+import Codify.submit.web.dto.SubjectResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+
+@RestController
+@RequestMapping("/api/submit/subjects")
+@RequiredArgsConstructor
+public class SubjectController {
+    private final SubjectService subjectService;
+
+    @PostMapping
+    public SubjectResponseDto create(
+            @RequestHeader("USER-UUID") String userUuidHeader, // 임시, 스프링 시큐리티 구현 후 대체 예정
+            @RequestBody SubjectRequestDto subjectRequestDto
+    ) {
+        UUID userUuid = UUID.fromString(userUuidHeader);
+        Long id = subjectService.create(userUuid, subjectRequestDto);
+        return new SubjectResponseDto(id, "과목이 성공적으로 생성되었습니다.");
+    }
+}

--- a/src/main/java/Codify/submit/web/dto/SubjectRequestDto.java
+++ b/src/main/java/Codify/submit/web/dto/SubjectRequestDto.java
@@ -1,0 +1,16 @@
+package Codify.submit.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubjectRequestDto {
+    @NotBlank
+    @Size(max = 255)
+    private String subjectName;
+}

--- a/src/main/java/Codify/submit/web/dto/SubjectResponseDto.java
+++ b/src/main/java/Codify/submit/web/dto/SubjectResponseDto.java
@@ -1,0 +1,13 @@
+package Codify.submit.web.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubjectResponseDto {
+    private Long subjectId;
+    private String message;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,8 @@ eureka:
 
   instance:
     prefer-ip-address: true
+
+codify:
+  dev:
+    user-uuid: ${USER-UUID}
+


### PR DESCRIPTION
### 설명
- 사용자(교수)가 과목을 생성하는 기능입니다.
- 스프링 시큐리티 도입 이전까지는 임시로 USER-UUID를 가지고 사용자를 식별합니다.
- 같은 사용자(교수)가 같은 과목을 생성하는 경우의 에러처리는, 스프링 시큐리티 도입 후에 테스트가 용이할 것 같아 추후 추가할 예정입니다.

### 변경사항
- swagger가 접속이 안되어서 버전을 2.8.9로 변경했습니다.
- 변경된 환경변수, 임시 USER-UUID는 노션 페이지에서 확인하시면 됩니다.